### PR TITLE
Eliminating pop ups

### DIFF
--- a/BinarySearchTree.html
+++ b/BinarySearchTree.html
@@ -50,7 +50,7 @@
         3. Print the tree<br>
         <input type="radio" name="direction" value="in"> Inorder (nodes visited left-parent-right)<br>
         <input type="radio" name="direction" value="pre"> Preorder (nodes visited parent-left-right)<br>
-        <input type="radio" name="direction" value="post"> Postorder (nodes visited right-left-parent)<br>
+        <input type="radio" name="direction" value="post"> Postorder (nodes visited left-right-parent)<br>
         <input type='button'  id='printEnter' value='print'><br>
         <br>
       </form>

--- a/BinarySearchTree.html
+++ b/BinarySearchTree.html
@@ -52,13 +52,18 @@
         5. Terminate the program<br>
         <input type='button'  id='terminateEnter' value='Terminate'>
       </form>
+      <!--object data="/images/test.pdf"></object-->
+      <h3></h3>
+      <p id="lastAction"></p>
       <script>
-      document.getElementById('addNode').style.display="none";
-      document.getElementById('removeNode').style.display="none";
-      document.getElementById('printTree').style.display="none";
-      document.getElementById('searchNode').style.display="none";
-      document.getElementById('terminateProgram').style.display="none";
+        document.getElementById('addNode').style.display="none";
+        document.getElementById('removeNode').style.display="none";
+        document.getElementById('printTree').style.display="none";
+        document.getElementById('searchNode').style.display="none";
+        document.getElementById('terminateProgram').style.display="none";
+        //document.querySelector('object').style.display="none";
+        //document.querySelector('h3').style.diplay="none";
       </script>
-      <script type="module" src="scripts/main.js"></script>
+      <script type="module" src="/scripts/main.js"></script>
     </body>
 </html>

--- a/BinarySearchTree.html
+++ b/BinarySearchTree.html
@@ -20,6 +20,18 @@
               <li> i.e. no duplicate values allowed
               <li> trying to add a duplicate will trigger a pop-up
             </ul>
+          <li> The text under the <q>Last action:</q> field displays the most recent <b>valid</b> operation on the tree
+            <ul>
+              <li> I am defining an invalid operation as the following:
+                <ol type="i">
+                  <li> entering a non-numeric input to any of the fields
+                  <li> trying to insert a duplicate value to the tree
+                  <li> trying to search for a value or remove a value from an empty tree
+                  <li> trying to print an empty tree
+                  <li> trying to print the tree with out selecting a printing order
+                </ol>
+              <li> Any of the above will trigger a pop-up
+            </ul>
         </ol>
       </p>
       <h2>Click button below to start</h2>
@@ -36,9 +48,9 @@
       </form>
       <form id="printTree" action="">
         3. Print the tree<br>
-        <input type="radio" name="direction" value="in"> Inorder<br>
-        <input type="radio" name="direction" value="pre"> Preorder<br>
-        <input type="radio" name="direction" value="post"> Postorder<br>
+        <input type="radio" name="direction" value="in"> Inorder (nodes visited left-parent-right)<br>
+        <input type="radio" name="direction" value="pre"> Preorder (nodes visited parent-left-right)<br>
+        <input type="radio" name="direction" value="post"> Postorder (nodes visited right-left-parent)<br>
         <input type='button'  id='printEnter' value='print'><br>
         <br>
       </form>

--- a/scripts/bst.js
+++ b/scripts/bst.js
@@ -77,44 +77,56 @@ export function BST(){
 
   function doSearch(input){
     //since this function is going to be to help insert+remove, it will be easier to make it iterative instead of recursive
-    var found=false;
-    var tmp=root;
-    var parent=tmp;
-    if(root.value!=null){
-      while(true){
-        if(input<tmp.value){
-          if(tmp.leftChild!=null){
-            parent=tmp;
-            tmp=tmp.leftChild;
-          }
-          else{
-            break;
-          }
-        }
-        else if(input>tmp.value){
-          if(tmp.rightChild!=null){
-            parent=tmp;
-            tmp=tmp.rightChild;
-          }
-          else{
-            //tmp has the value we searched for
-            break;
-          }
-        }
-        else{
-          //found it
-          found=true;
-          break;
-        }
-      }
-      //now, tmp is either the node holding the value we searched for, or is the node that would be that value's parent
-      var searchInfo={
-        found:found,
-        tmp:tmp,
-        parent:parent
-      };
-      return searchInfo;
+    if(isNaN(input)){
+      alert("please enter a numeric value");
     }
+    else{
+      var found=false;
+      var tmp=root;
+      var parent=tmp;
+
+      if(root.value!=null){
+        while(true){
+          if(input<tmp.value){
+            if(tmp.leftChild!=null){
+              parent=tmp;
+              tmp=tmp.leftChild;
+            }
+            else{
+              break;
+            }
+          }
+          else if(input>tmp.value){
+            if(tmp.rightChild!=null){
+              parent=tmp;
+              tmp=tmp.rightChild;
+            }
+            else{
+              //tmp has the value we searched for
+              break;
+            }
+          }
+          else{
+            //found it
+            found=true;
+            break;
+          }
+        }
+        //now, tmp is either the node holding the value we searched for, or is the node that would be that value's parent
+
+        var searchInfo={
+          found:found,
+          tmp:tmp,
+          parent:parent
+        };
+        
+        return searchInfo;
+      }
+      else{
+        alert("tree is empty, cannot search for a value");
+      }
+    }
+
   }
 
   function doRemove(input){
@@ -124,45 +136,50 @@ export function BST(){
       2. The node we are deleting has a single child node
       3. The node we are deleting has two child nodes
     */
-    if(root.value!=null){
-      //there are things in the tree
-      var search=doSearch(input)
-      if(search.found==true){
-        //value is in the tree
-        if(search.tmp.leftChild==null && search.tmp.rightChild==null){
-          //Case 1: node has no child nodes
-          removeNoChild(search.tmp, search.parent);
-        }
-        else if(search.tmp.leftChild!=null && search.tmp.rightChild==null){
-          //Case 2(a): node only has left child node
-          removeLeftChild(search.tmp, search.parent);
-        }
-        else if(search.tmp.leftChild==null && search.tmp.rightChild!=null){
-          //Case 2(b): node only has right child node
-          removeRightChild(search.tmp, search.parent);
-        }
-        else{
-          //Case 3: parent has two children
-          var subTreeMin=findSubTreeMin(search.tmp.rightChild);
-          removeTwoChild(search.tmp, subTreeMin.value); //set nodes value to that of its right subtree's minimum
-          //delete node w/ right subtree's minimum
-          if(subTreeMin.rightChild==null){
-            removeNoChild(subTreeMin, subTreeMin.parent);
-          }
-          else{
-            removeRightChild(subTreeMin, subTreeMin.parent);
-          }
-
-        }
-        alert(input+ " has been removed from the tree");
-      }
-      else{
-        alert(input+" is not in the tree");
-      }
-
+    if(isNaN(input)){
+      alert("please enter a numeric value");
     }
     else{
-      alert("tree is empty, cannot remove anything")
+      if(root.value!=null){
+        //there are things in the tree
+        var search=doSearch(input)
+        if(search.found==true){
+          //value is in the tree
+          if(search.tmp.leftChild==null && search.tmp.rightChild==null){
+            //Case 1: node has no child nodes
+            removeNoChild(search.tmp, search.parent);
+          }
+          else if(search.tmp.leftChild!=null && search.tmp.rightChild==null){
+            //Case 2(a): node only has left child node
+            removeLeftChild(search.tmp, search.parent);
+          }
+          else if(search.tmp.leftChild==null && search.tmp.rightChild!=null){
+            //Case 2(b): node only has right child node
+            removeRightChild(search.tmp, search.parent);
+          }
+          else{
+            //Case 3: parent has two children
+            var subTreeMin=findSubTreeMin(search.tmp.rightChild);
+            removeTwoChild(search.tmp, subTreeMin.value); //set nodes value to that of its right subtree's minimum
+            //delete node w/ right subtree's minimum
+            if(subTreeMin.rightChild==null){
+              removeNoChild(subTreeMin, subTreeMin.parent);
+            }
+            else{
+              removeRightChild(subTreeMin, subTreeMin.parent);
+            }
+
+          }
+          return (input+ " has been removed from the tree");
+        }
+        else{
+          alert(input+" is not in the tree");
+        }
+
+      }
+      else{
+        alert("tree is empty, cannot remove anything")
+      }
     }
   }
 

--- a/scripts/bst.js
+++ b/scripts/bst.js
@@ -34,27 +34,32 @@ export function BST(){
   var root=bstNode();
 
   function doInsert(input){
-    var newNode=bstNode();
-    newNode.setValue(input);
-    if(root.value==null){
-      //list is empty
-      root=newNode;
-      return(input+" was added to the tree as the root");
+    if(isNaN(input)){
+      alert("only numeric values are allowed in the tree");
     }
     else{
-      var tmp=root;
-      var parent=root;
-      var search=doSearch(input);
-      if(search.found==true){
-        //value already in tree
-        alert(input + " is already in the tree");
+      var newNode=bstNode();
+      newNode.setValue(input);
+      if(root.value==null){
+        //list is empty
+        root=newNode;
+        return(input+" was added to the tree as the root");
       }
       else{
-        if(input<search.tmp.value){
-          return leftInsert(newNode, search.tmp);
+        var tmp=root;
+        var parent=root;
+        var search=doSearch(input);
+        if(search.found==true){
+          //value already in tree
+          alert(input + " is already in the tree");
         }
         else{
-          return rightInsert(newNode, search.tmp);
+          if(input<search.tmp.value){
+            return leftInsert(newNode, search.tmp);
+          }
+          else{
+            return rightInsert(newNode, search.tmp);
+          }
         }
       }
     }

--- a/scripts/bst.js
+++ b/scripts/bst.js
@@ -39,7 +39,7 @@ export function BST(){
     if(root.value==null){
       //list is empty
       root=newNode;
-      alert(input+" was added to the tree as the root");
+      return(input+" was added to the tree as the root");
     }
     else{
       var tmp=root;
@@ -51,10 +51,10 @@ export function BST(){
       }
       else{
         if(input<search.tmp.value){
-          leftInsert(newNode, search.tmp);
+          return leftInsert(newNode, search.tmp);
         }
         else{
-          rightInsert(newNode, search.tmp);
+          return rightInsert(newNode, search.tmp);
         }
       }
     }
@@ -62,12 +62,12 @@ export function BST(){
   function leftInsert(newNode, parentNode){
     parentNode.setLeftChild(newNode);
     newNode.setParent(parentNode);
-    alert(newNode.value+" was added to the tree as the left child to "+ parentNode.value);
+    return(newNode.value+" was added to the tree as the left child to "+ parentNode.value);
   }
   function rightInsert(newNode, parentNode){
     parentNode.setRightChild(newNode);
     newNode.setParent(parentNode);
-    alert(newNode.value+" was added to the tree as the right child to "+ parentNode.value);
+    return(newNode.value+" was added to the tree as the right child to "+ parentNode.value);
   }
 
   function doSearch(input){

--- a/scripts/bst.js
+++ b/scripts/bst.js
@@ -119,7 +119,7 @@ export function BST(){
           tmp:tmp,
           parent:parent
         };
-        
+
         return searchInfo;
       }
       else{
@@ -275,8 +275,8 @@ export function BST(){
       alert("tree is empty")
     }else{
       var treeString="";
-      treeString="tree contains(in-order):\r"+treeString+doPrintInorder(root, treeString);
-      alert(treeString);
+      treeString="tree contains(in-order):<br>"+treeString+doPrintInorder(root, treeString);
+      return treeString;
     }
   }
   function doPrintInorder(node, treeString){
@@ -286,7 +286,7 @@ export function BST(){
       treeString=doPrintInorder(node.leftChild, treeString);
     }
     //alert(node.value);
-    treeString=treeString+node.value+"\r";
+    treeString=treeString+node.value+"<br>";
     if(node.rightChild!=null){
       treeString=doPrintInorder(node.rightChild, treeString);
     }
@@ -304,15 +304,15 @@ export function BST(){
       alert("tree is empty");
     }else{
       var treeString="";
-      treeString="tree contains(pre-order):\r"+treeString+doPrintPreorder(root, treeString);
-      alert(treeString);
+      treeString="tree contains(pre-order):<br>"+treeString+doPrintPreorder(root, treeString);
+      return treeString;
     }
   }
   function doPrintPreorder(node,treeString){
     //this function actually does the preorder printing
     //alert(node.value);
     //treeString=treeString+node.value+"\r";
-    treeString=treeString+node.value+"\r";
+    treeString=treeString+node.value+"<br>";
     if(node.leftChild!=null){
       treeString=doPrintPreorder(node.leftChild, treeString);
     }
@@ -333,8 +333,8 @@ export function BST(){
       alert("tree is empty");
     }else{
       var treeString="";
-      treeString="tree contains(post-order):\r"+treeString+doPrintPostorder(root, treeString);
-      alert(treeString);
+      treeString="tree contains(post-order):<br>"+treeString+doPrintPostorder(root, treeString);
+      return treeString;
     }
   }
   function doPrintPostorder(node, treeString){
@@ -345,7 +345,7 @@ export function BST(){
     if(node.rightChild!=null){
       treeString=doPrintPostorder(node.rightChild, treeString);
     }
-    treeString=treeString+node.value+"\r";
+    treeString=treeString+node.value+"<br>";
     return treeString;
   }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -14,6 +14,7 @@ import {BST} from "./bst.js";
 
 var tree= BST();  //the binary search tree
 
+var lastAction=document.getElementById("lastAction");
 //the various buttons:
 var startButton=document.getElementById('start');
 var insertButton=document.getElementById("insertEnter");
@@ -32,13 +33,17 @@ startButton.onclick=function(){
   document.getElementById('printTree').style.display="block";
   document.getElementById('searchNode').style.display="block";
   document.getElementById('terminateProgram').style.display="block";
+  document.querySelector('h3').textContent="Last action:";
 }
 
 insertButton.onclick=function(){
   var insert=document.getElementById('addNode');
   var userInput=insert.elements[0].value;
-  tree.insert(Number(userInput));
   insert.elements[0].value=""; //clear form
+  var action=tree.insert(Number(userInput));
+  if(action!=null){
+    lastAction.textContent=action;  //update last action paragraph
+  }
 }
 removeButton.onclick=function(){
   var remove=document.getElementById('removeNode');

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -48,20 +48,27 @@ insertButton.onclick=function(){
 removeButton.onclick=function(){
   var remove=document.getElementById('removeNode');
   var userInput=remove.elements[0].value;
-  tree.remove(Number(userInput));
   remove.elements[0].value=""; //clear form
+  var action=tree.remove(Number(userInput));
+  if(action!=null){
+    lastAction.textContent=action;  //update last action paragraph
+  }
 }
 searchButton.onclick=function(){
   var search=document.getElementById('searchNode');
   var userInput=search.elements[0].value;
-  if(tree.search(Number(userInput)).found){
-    //value was in list
-    alert(userInput+" is in the tree");
-  }else{
-    //not in list
-    alert(userInput+" is not in the tree");
-  }
   search.elements[0].value=""; //clear form
+  var action=tree.search(Number(userInput));
+  if(action!=null){
+    //there are things in tree+user entered valid input
+    if(tree.search(Number(userInput)).found){
+      //value was in list
+      lastAction.textContent=(userInput+" is in the tree");
+    }else{
+      //not in list
+      lastAction.textContent=(userInput+" is not in the tree");
+    }
+  }
 }
 printButton.onclick=function(){
   var print=document.getElementById('printTree');

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -76,20 +76,20 @@ printButton.onclick=function(){
   if(print.elements[0].checked){
     //inorder button pressed
     tree.changePrint("in");
-    //listContents=list.print();
-    tree.print();
+    treeContents=tree.print();
+    lastAction.innerHTML=treeContents;
   }
   else if(print.elements[1].checked){
     //preorder button pressed
     tree.changePrint("pre");
-    //listContents=list.print();
-    tree.print();
+    treeContents=tree.print();
+    lastAction.innerHTML=treeContents;
   }
   else if(print.elements[2].checked){
     //postorder button pressed
     tree.changePrint("post");
-    //listContents=list.print();
-    tree.print();
+    treeContents=tree.print();
+    lastAction.innerHTML=treeContents;
   }
   else{
     //user did not press either button

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -14,7 +14,7 @@ import {BST} from "./bst.js";
 
 var tree= BST();  //the binary search tree
 
-var lastAction=document.getElementById("lastAction");
+var lastAction=document.getElementById("lastAction"); //paragraph diplaying last valid operation performed on the tree
 //the various buttons:
 var startButton=document.getElementById('start');
 var insertButton=document.getElementById("insertEnter");
@@ -28,12 +28,15 @@ startButton.onclick=function(){
   document.querySelector('h2').textContent="Choose from the following:"; //change initial instruction
   document.getElementById("welcome").style.display="none"; //hide program info
   document.querySelector('ol').style.display="none";
+  //display all forms:
   document.getElementById('addNode').style.display="block";
   document.getElementById('removeNode').style.display="block";
   document.getElementById('printTree').style.display="block";
   document.getElementById('searchNode').style.display="block";
   document.getElementById('terminateProgram').style.display="block";
+  //create last action header+give starting state
   document.querySelector('h3').textContent="Last action:";
+  lastAction.textContent="no valid operations have been performed yet";
 }
 
 insertButton.onclick=function(){
@@ -77,19 +80,25 @@ printButton.onclick=function(){
     //inorder button pressed
     tree.changePrint("in");
     treeContents=tree.print();
-    lastAction.innerHTML=treeContents;
+    if(treeContents!=null){
+      lastAction.innerHTML=treeContents;
+    }
   }
   else if(print.elements[1].checked){
     //preorder button pressed
     tree.changePrint("pre");
     treeContents=tree.print();
-    lastAction.innerHTML=treeContents;
+    if(treeContents!=null){
+      lastAction.innerHTML=treeContents;
+    }
   }
   else if(print.elements[2].checked){
     //postorder button pressed
     tree.changePrint("post");
     treeContents=tree.print();
-    lastAction.innerHTML=treeContents;
+    if(treeContents!=null){
+      lastAction.innerHTML=treeContents;
+    }
   }
   else{
     //user did not press either button
@@ -104,4 +113,7 @@ terminateButton.onclick=function(){
   document.getElementById('printTree').style.display="none";
   document.getElementById('searchNode').style.display="none";
   document.getElementById('terminateProgram').style.display="none";
+  //hide last action field
+  document.querySelector('h3').style.display="none";
+  lastAction.style.display="none"
 }


### PR DESCRIPTION
Eliminated a lot of the unnecessary pop-ups by adding a field which displays the last valid operation that was performed on the tree. Pop-ups will now only occur if the user attempts to perform an invalid operation on the tree, which is a logical use for pop-ups. 

I have defined an invalid operation as attempting to insert a duplicate a value to the tree, trying to perform a search/remove/print on an empty tree, trying to print the tree w/o selecting a print order, or trying to enter a non-numeric value into any of the fields